### PR TITLE
Add ability to unescape html arbitrarily.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,9 @@ export default (literals, ...substs) => {
 
 		if (Array.isArray(subst)) {
 			subst = subst.join("");
+		} else if (acc[acc.length - 1] === "!") {
+			acc = acc.slice(0, -1);
+			subst = String(subst);
 		} else {
 			subst = htmlEscape(subst);
 		}


### PR DESCRIPTION
This PR makes it so that you can prefix any interpolation (besides arrays) with a "!" and override html escaping.

This is handy for things like embedding markdown, wysiwyg's etc.
