### PR TITLE
Added option for skipping autoescape

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,12 +55,9 @@ var string = html`
 
 ### Skip autoscaping
 
-You can use double dolar signs in interpolation to mark the value as safe (which means that this variable will not be escaped).
+You can use double dollar signs in interpolation to mark the value as safe (which means that this variable will not be escaped).
 
 ```javascript
-var html = require("html-template-tag");
-// - or - import html from "html-template-tag";
-
 var name = `<strong>Antonio</strong>`;
 var string = html`Hello, $${name}!`;
 // "Hello, <strong>Antonio</strong>!"

--- a/README.md
+++ b/README.md
@@ -53,6 +53,21 @@ var string = html`
 // "<ul><li>Hello, Antonio!</li><li>Hello, Megan!</li><li>Hello, /&gt;&lt;script&gt;alert(&#39;xss&#39;)&lt;/script&gt;!</li></ul>"
 ```
 
+### Skip autoscaping
+
+You can use double dolar signs in interpolation to mark the value as safe (which means that this variable will not be escaped).
+
+```javascript
+var html = require("html-template-tag");
+// - or - import html from "html-template-tag";
+
+var name = `<strong>Antonio</strong>`;
+var string = html`Hello, $${name}!`;
+// "Hello, <strong>Antonio</strong>!"
+```
+
+
+
 ### HTML Template Pre-Compiling
 
 This small module can also be used to pre-compile HTML templates:

--- a/src/index.js
+++ b/src/index.js
@@ -4,10 +4,13 @@ import htmlEscape from "html-es6cape";
 
 export default (literals, ...substs) => {
 	return literals.raw.reduce((acc, lit, i) => {
-		var subst = substs[i - 1];
-
+		let subst = substs[i - 1];
 		if (Array.isArray(subst)) {
 			subst = subst.join("");
+		} else if (acc.endsWith('$')) {
+			// If the interpolation is preceded by a dollar sign,
+			// substitution is considered safe and will not be escaped
+			acc = acc.slice(0, -1);
 		} else {
 			subst = htmlEscape(subst);
 		}

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -31,6 +31,11 @@ describe("html-template-tag", () => {
 		});
 	});
 
+	it("should skip escaping HTML special characters for substituitions with double $", () => {
+		let safeString = "<strong>Antonio</strong>"
+		expect(html`Hello, $${safeString}!`).to.equal("Hello, <strong>Antonio</strong>!");
+	})
+
 	it("should generate valid HTML with an array of values", () => {
 		let names = ["Megan", "Tiphaine", "Florent", "Hoan"];
 


### PR DESCRIPTION
Hi 

In some very specific circumstances I need to interpolate a safe value as-is. So, I added an option to to mark a value as safe (using double dollar signs), which means that this variable will not be escaped.