### PR TITLE
fix: allow arrays in types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import escape from "html-es6cape";
 
 function htmlTemplateTag(
   literals: TemplateStringsArray,
-  ...substs: string[]
+  ...substs: Array<string | string[]>
 ): string {
   return literals.raw.reduce((acc, lit, i) => {
     let subst = substs[i - 1];


### PR DESCRIPTION
Currently the types don't allow you to pass an array of strings, which prevents you from using a core feature of this library.