### PR TITLE
Fix vulnerabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,11 +38,9 @@ var html = require("html-template-tag");
 
 var names = ["Antonio", "Megan", "/><script>alert('xss')</script>"];
 var string = html`
-	<ul>
-		${names.map((name) => html`
-			<li>Hello, ${name}!</li>
-		`)}
-	</ul>
+  <ul>
+    ${names.map((name) => html` <li>Hello, ${name}!</li> `)}
+  </ul>
 `;
 // "<ul><li>Hello, Antonio!</li><li>Hello, Megan!</li><li>Hello, /&gt;&lt;script&gt;alert(&#39;xss&#39;)&lt;/script&gt;!</li></ul>"
 ```
@@ -66,16 +64,14 @@ var html = require("html-template-tag");
 // - or - import { html } from "html-template-tag";
 
 var data = {
-	count: 2,
-	names: ["Antonio", "Megan"]
+  count: 2,
+  names: ["Antonio", "Megan"],
 };
 
-var template = ({names}) => html`
-	<ul>
-		${names.map((name) => html`
-			<li>Hello, ${name}!</li>
-		`)}
-	</ul>
+var template = ({ names }) => html`
+  <ul>
+    ${names.map((name) => html` <li>Hello, ${name}!</li> `)}
+  </ul>
 `;
 
 var string = template(data);
@@ -88,10 +84,17 @@ var string = template(data);
 	"
 */
 ```
+
 > NB: The formating of the string literal is kept.
 
+### Interpolation inside URI attributes
+
+To avoid XSS attacks, this package removes all interpolation instide URI attributes ([more info](https://cheatsheetseries.owasp.org/cheatsheets/XSS_Filter_Evasion_Cheat_Sheet.html)). This package also ensures that interpolations inside attributes are properly escaped.
+
 ## License
+
 MIT
 
 ## Thanks
+
 The code for this module has been heavily inspired on [Axel Rauschmayer's post on HTML templating with ES6 template strings](http://www.2ality.com/2015/01/template-strings-html.html) and [Stefan Bieschewski's comment](http://www.2ality.com/2015/01/template-strings-html.html#comment-2078932192).

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "4.0.1",
       "license": "MIT",
       "dependencies": {
+        "html-element-attributes": "^3.4.0",
         "html-es6cape": "^2.0.0"
       },
       "devDependencies": {
@@ -1548,6 +1549,15 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/html-element-attributes": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/html-element-attributes/-/html-element-attributes-3.4.0.tgz",
+      "integrity": "sha512-u76G07278nacmHiSKs1yxbB2se0aiuQH8uJidyDMc6har3HRpFAR/sDKrZR426p03vu7QuvPAcaLMhp4kWcRbg==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/html-es6cape": {
@@ -4296,6 +4306,11 @@
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true
+    },
+    "html-element-attributes": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/html-element-attributes/-/html-element-attributes-3.4.0.tgz",
+      "integrity": "sha512-u76G07278nacmHiSKs1yxbB2se0aiuQH8uJidyDMc6har3HRpFAR/sDKrZR426p03vu7QuvPAcaLMhp4kWcRbg=="
     },
     "html-es6cape": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "vitest": "^0.9.3"
   },
   "dependencies": {
+    "html-element-attributes": "^3.4.0",
     "html-es6cape": "^2.0.0"
   }
 }

--- a/src/attributes.ts
+++ b/src/attributes.ts
@@ -1,0 +1,44 @@
+import { htmlElementAttributes } from "html-element-attributes";
+
+export const attributes = Object.values(htmlElementAttributes).flat();
+
+export function endsWithUnescapedAttribute(acc: string): boolean {
+  return attributes.some((attribute) => acc.endsWith(`${attribute}=`));
+}
+
+export const attributesUri = [
+  "action",
+  "archive",
+  "background",
+  "cite",
+  "classid",
+  "codebase",
+  "content",
+  "data",
+  "dynsrc",
+  "formaction",
+  "href",
+  "icon",
+  "imagesrcset",
+  "longdesc",
+  "lowsrc",
+  "manifest",
+  "nohref",
+  "onload",
+  "poster",
+  "popovertargetaction",
+  "profile",
+  "src",
+  "srcset",
+  "style",
+  "usemap",
+];
+
+export const endsWithUriAttribute = function endsWithAttributes(
+  acc: string
+): boolean {
+  return attributesUri.some(
+    (attribute) =>
+      acc.endsWith(`${attribute}=`) || acc.endsWith(`${attribute}="`)
+  );
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,12 @@
 // Inspired on http://www.2ality.com/2015/01/template-strings-html.html#comment-2078932192
 
 import escape from "html-es6cape";
+import { htmlElementAttributes } from "html-element-attributes";
+
+const attributes = Object.values(htmlElementAttributes).flat();
+function endsWithUnescapedAttribute(acc: string): boolean {
+  return attributes.some((attribute) => acc.endsWith(`${attribute}=`));
+}
 
 function htmlTemplateTag(
   literals: TemplateStringsArray,
@@ -16,6 +22,21 @@ function htmlTemplateTag(
       acc = acc.slice(0, -1);
     } else {
       subst = escape(subst);
+    }
+
+    /*
+     * If the interpolation is preceded by an unescaped attribute, we need to
+     * add quotes around the substitution to avoid XSS attacks.
+     *
+     * ```
+     * const foo = "Alt onload=alert(1)";
+     * html`<img src="..." alt=${foo} />`
+     *    => <img src="..." alt=Alt onload=alert(1) />
+     * ```
+     */
+    if (endsWithUnescapedAttribute(acc)) {
+      acc += '"';
+      lit = '"' + lit;
     }
 
     return acc + subst + lit;

--- a/test.html
+++ b/test.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Test</title>
+  </head>
+  <body>
+    <h1>Test</h1>
+    <p>Test</p>
+    <div id="div"></div>
+  </body>
+  <script>
+    const alt = 'test onLoad=alert(1)'
+    document.getElementById('div').innerHTML = `<img src="https://avatars.githubusercontent.com/u/5470315" alt=${alt} />`;
+  </script>
+</html>

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -75,4 +75,21 @@ describe("html-template-tag", () => {
       </div>`
     );
   });
+
+  it("should add quotes around alt attribute", () => {
+    const src = "https://example.com/image.jpg";
+    const alt = "Alt onload=alert(1)";
+    console.log(html`<img src="${src}" alt=${alt} />`);
+    expect(html`<img src="${src}" alt=${alt} />`).toEqual(
+      `<img src="https://example.com/image.jpg" alt="Alt onload=alert(1)" />`
+    );
+  });
+
+  it("should not add quotes around alt attribute if they are already present", () => {
+    const src = "https://example.com/image.jpg";
+    const alt = "Alt onload=alert(1)";
+    expect(html`<img src="${src}" alt="${alt}" />`).toEqual(
+      `<img src="https://example.com/image.jpg" alt="Alt onload=alert(1)" />`
+    );
+  });
 });

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,8 +1,21 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 
 import html from "../src";
+import { attributes, attributesUri } from "../src/attributes";
+
+const attributesNoUri = attributes.filter(
+  (attribute) => !attributesUri.includes(attribute)
+);
 
 describe("html-template-tag", () => {
+  const consoleWarnSpy = vi
+    .spyOn(console, "warn")
+    .mockImplementation(() => undefined);
+
+  beforeEach(() => {
+    consoleWarnSpy.mockReset();
+  });
+
   it("should return a string when passed a string literal", () => {
     expect(typeof html`Hello, world!`).toEqual("string");
   });
@@ -76,20 +89,37 @@ describe("html-template-tag", () => {
     );
   });
 
-  it("should add quotes around alt attribute", () => {
-    const src = "https://example.com/image.jpg";
-    const alt = "Alt onload=alert(1)";
-    console.log(html`<img src="${src}" alt=${alt} />`);
-    expect(html`<img src="${src}" alt=${alt} />`).toEqual(
-      `<img src="https://example.com/image.jpg" alt="Alt onload=alert(1)" />`
-    );
-  });
+  it.each(attributesNoUri)(
+    "should add quotes around attribute '%s'",
+    (attribute) => {
+      const value = "Alt onload=alert(1)";
+      expect(html`<div ${attribute}=${value} />`).toEqual(
+        `<div ${attribute}="Alt onload=alert(1)" />`
+      );
+    }
+  );
 
-  it("should not add quotes around alt attribute if they are already present", () => {
-    const src = "https://example.com/image.jpg";
-    const alt = "Alt onload=alert(1)";
-    expect(html`<img src="${src}" alt="${alt}" />`).toEqual(
-      `<img src="https://example.com/image.jpg" alt="Alt onload=alert(1)" />`
-    );
-  });
+  it.each(attributesNoUri)(
+    "should not add quotes around attribute '%s' if they are already present",
+    (attribute) => {
+      const value = "Alt onload=alert(1)";
+      expect(html`<div ${attribute}="${value}" />`).toEqual(
+        `<div ${attribute}="Alt onload=alert(1)" />`
+      );
+    }
+  );
+
+  it.each(attributesUri)(
+    "should remove the interpolation if preceeded by an attribute that takes a URI ('%s')",
+    (attribute) => {
+      const value = "some string";
+      expect(html`<div ${attribute}="${value}" />`).toEqual(
+        `<div ${attribute}="" />`
+      );
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        "[html-template-tag] Trying to interpolate inside an URI attribute. This can lead to security vulnerabilities. The interpolation has been removed.",
+        { acc: `<div ${attribute}="`, subst: value, lit: `" />` }
+      );
+    }
+  );
 });


### PR DESCRIPTION
This PR fixes a couple of reported XSS vulnerabilities:
- Properly escapes interpolations inside HTML attributes (which wasn't the case previously and could lead to XSS if the attributes weren't escaped)
- Removing interpolations inside HTML attributes accepting URIs (it was easier than to deal with all possible [issues](https://cheatsheetseries.owasp.org/cheatsheets/XSS_Filter_Evasion_Cheat_Sheet.html))